### PR TITLE
Export `MutatorWrapper` from fuzzcheck

### DIFF
--- a/fuzzcheck/src/lib.rs
+++ b/fuzzcheck/src/lib.rs
@@ -34,6 +34,8 @@ pub use mutators::DefaultMutator;
 #[doc(inline)]
 pub use traits::Mutator;
 #[doc(inline)]
+pub use traits::MutatorWrapper;
+#[doc(inline)]
 pub use traits::Serializer;
 
 #[doc(inline)]


### PR DESCRIPTION
`MutatorWrapper` is pretty useful trait. With it we can easily create custom mutators that wrap on existing ones. For example one can wrap `FixedLenVecMutator` to create custom mutator, which will only generate vectors with concrete fixed length, based on the type.