### PR TITLE
Update some documentation items

### DIFF
--- a/fuzzcheck/src/builder.rs
+++ b/fuzzcheck/src/builder.rs
@@ -257,7 +257,7 @@ where
     /**
         Specify the serializer to use when saving the interesting test cases to the file system.
 
-        The serializer must conform the [Serializer](fuzzcheck_traits::Serializer) trait. If you wish
+        The serializer must implement the [Serializer](fuzzcheck_traits::Serializer) trait. If you wish
         to use `serde`, you can compile fuzzcheck with the `serde_json_serializer` feature, which exposes
         `fuzzcheck::fuzzcheck_serializer::SerdeSerializer`. You can then write:
         ```ignore

--- a/fuzzcheck/src/mutators/grammar/ast.rs
+++ b/fuzzcheck/src/mutators/grammar/ast.rs
@@ -13,7 +13,8 @@ pub enum AST {
     Box(Box<AST>),
 }
 impl ASTMutator {
-    /// Wrap the mutator in a
+    /// Transforms the [ASTMutator] into a mutator which passes both the [AST] type and that [AST]
+    /// instance as a [String] (rather than just the [AST]).
     pub fn with_string(self) -> impl Mutator<(AST, String)> {
         MapMutator::new(
             self,

--- a/fuzzcheck/src/mutators/grammar/grammar.rs
+++ b/fuzzcheck/src/mutators/grammar/grammar.rs
@@ -5,21 +5,33 @@ use std::{
 };
 
 #[derive(Clone, Debug)]
+/// A grammar which can be used for fuzzing.
+///
+/// Note that instead of constructing these yourself you probably want to use the provided macros
+/// (see the documentation for each field for the appropriate macro to use).
 pub enum Grammar {
+    /// [crate::literal]
     Literal(Vec<RangeInclusive<char>>),
+    /// [crate::alternation]
     Alternation(Vec<Rc<Grammar>>),
+    /// [crate::concatenation]
     Concatenation(Vec<Rc<Grammar>>),
+    /// [crate::repetition]
     Repetition(Rc<Grammar>, Range<usize>),
+    /// [crate::recurse]
     Recurse(Weak<Grammar>),
+    /// [crate::recursive]
     Recursive(Rc<Grammar>),
 }
 
 impl Grammar {
     #[no_coverage]
+    /// You may want to use the [crate::literal] macro instead of invoking this function directly.
     pub fn literal_ranges(ranges: Vec<RangeInclusive<char>>) -> Rc<Grammar> {
         Rc::new(Grammar::Literal(ranges))
     }
     #[no_coverage]
+    /// You may want to use the [crate::literal] macro instead of invoking this function directly.
     pub fn literal<R>(range: R) -> Rc<Grammar>
     where
         R: RangeBounds<char>,
@@ -37,14 +49,19 @@ impl Grammar {
         Rc::new(Grammar::Literal(vec![start..=end]))
     }
     #[no_coverage]
+    /// You may want to use the [crate::alternation] macro instead of invoking this function directly.
     pub fn alternation(gs: impl IntoIterator<Item = Rc<Grammar>>) -> Rc<Grammar> {
         Rc::new(Grammar::Alternation(gs.into_iter().collect()))
     }
     #[no_coverage]
+    /// You may want to use the [crate::concatenation] macro instead of invoking this function
+    /// directly.
     pub fn concatenation(gs: impl IntoIterator<Item = Rc<Grammar>>) -> Rc<Grammar> {
         Rc::new(Grammar::Concatenation(gs.into_iter().collect()))
     }
     #[no_coverage]
+    /// You may want to use the [crate::repetition] macro instead of invoking this function
+    /// directly.
     pub fn repetition<R>(gs: Rc<Grammar>, range: R) -> Rc<Grammar>
     where
         R: RangeBounds<usize>,
@@ -63,10 +80,12 @@ impl Grammar {
     }
 
     #[no_coverage]
+    /// You may want to use the [crate::recurse] macro instead of invoking this function directly.
     pub fn recurse(g: &Weak<Grammar>) -> Rc<Grammar> {
         Rc::new(Grammar::Recurse(g.clone()))
     }
     #[no_coverage]
+    /// You may want to use the [crate::recursive] macro instead of invoking this function directly.
     pub fn recursive(data_fn: impl Fn(&Weak<Grammar>) -> Rc<Grammar>) -> Rc<Grammar> {
         Rc::new(Grammar::Recursive(Rc::new_cyclic(|g| {
             Rc::try_unwrap(data_fn(g)).unwrap()

--- a/fuzzcheck/src/mutators/mod.rs
+++ b/fuzzcheck/src/mutators/mod.rs
@@ -16,7 +16,7 @@ a non-recursive `struct` or `enum` and makes it its default mutator.
 - [`make_basic_tuple_mutator!(N)`](fuzzcheck_mutators_derive::make_mutator) creates a mutator for tuples of `N`
 elements. For small values of `N`, these mutators are already available in [the `tuples` module](crate::mutators::tuples)
 
-This crate provides [grammar-based string mutators](crate::grammar).
+This crate provides [grammar-based string mutators](crate::mutators::grammar).
 */
 
 pub use fuzzcheck_mutators_derive::*;

--- a/fuzzcheck/src/mutators/recursive.rs
+++ b/fuzzcheck/src/mutators/recursive.rs
@@ -25,7 +25,7 @@ struct S {
 }
 ```
 `RecursiveMutator` is only the top-level type. It must be used in conjuction
-with [RecurToMutator](crate::recursive::RecurToMutator) at points of recursion.
+with [RecurToMutator](crate::mutators::recursive::RecurToMutator) at points of recursion.
 For example:
 ```ignore
 use fuzzcheck_mutators::recursive::RecursiveMutator;
@@ -50,7 +50,8 @@ impl<M> RecursiveMutator<M> {
     }
 }
 
-/// A mutator that defers to a weak reference of a [RecursiveMutator](crate::recursive::RecursiveMutator)
+/// A mutator that defers to a weak reference of a
+/// [RecursiveMutator](crate::mutators::recursive::RecursiveMutator)
 pub struct RecurToMutator<M> {
     reference: Weak<M>,
 }


### PR DESCRIPTION
I initially was a bit confused by all the types in `grammar`, so I think pointing people to the macros is helpful.