### PR TITLE
fix out-of-bounds access bug

### DIFF
--- a/fuzzcheck/src/code_coverage_sensor/mod.rs
+++ b/fuzzcheck/src/code_coverage_sensor/mod.rs
@@ -109,20 +109,22 @@ impl Sensor for CodeCoverageSensor {
             let CodeCoverageSensor { coverage, .. } = self;
             let mut index = 0;
             for coverage in coverage {
-                let single = *coverage.single_counters.get_unchecked(0);
-                if *single == 0 {
-                    // that happens kind of a lot? not sure it is worth simplifying
-                    index += coverage.single_counters.len() + coverage.expression_counters.len();
-                    continue;
-                } else {
-                    handler((index, *single));
-                }
-                index += 1;
-                for &single in coverage.single_counters.iter().skip(1) {
-                    if *single != 0 {
+                if !coverage.single_counters.is_empty() {
+                    let single = *coverage.single_counters.get_unchecked(0);
+                    if *single == 0 {
+                        // that happens kind of a lot? not sure it is worth simplifying
+                        index += coverage.single_counters.len() + coverage.expression_counters.len();
+                        continue;
+                    } else {
                         handler((index, *single));
                     }
                     index += 1;
+                    for &single in coverage.single_counters.iter().skip(1) {
+                        if *single != 0 {
+                            handler((index, *single));
+                        }
+                        index += 1;
+                    }    
                 }
                 for expr in &coverage.expression_counters {
                     let computed = expr.compute();


### PR DESCRIPTION
Unsafe access to the first vector element when the vector was empty was causing a segmentation fault when using fuzzcheck. This patch fixes it.

```
Thread 3.1 "action_fuzz-b00" received signal SIGSEGV, Segmentation fault.

[Switching to Thread 0x7ffff7a453c0 (LWP 574366)]
0x0000555555bb1c7c in <fuzzcheck::code_coverage_sensor::CodeCoverageSensor as fuzzcheck::traits::Sensor>::iterate_over_observations ()
(gdb) bt
#0  0x0000555555bb1c7c in <fuzzcheck::code_coverage_sensor::CodeCoverageSensor as fuzzcheck::traits::Sensor>::iterate_over_observations ()
#1  0x00005555557d487a in <fuzzcheck::sensors_and_pools::and_sensor_and_pool::AndPool<fuzzcheck::sensors_and_pools::simplest_to_activate_counter_pool::SimplestToActivateCounterPool, fuzzcheck::sensors_and_pools::and_sensor_and_pool::AndPool<fuzzcheck::sensors_and_pools::and_sensor_and_pool::AndPool<fuzzcheck::sensors_and_pools::most_n_diverse_pool::MostNDiversePool, fuzzcheck::sensors_and_pools::optimise_aggregate_stat_pool::OptimiseAggregateStatPool<fuzzcheck::sensors_and_pools::optimise_aggregate_stat_pool::NumberOfActivatedCounters>>, fuzzcheck::sensors_and_pools::and_sensor_and_pool::AndPool<fuzzcheck::sensors_and_pools::maximise_counter_value_pool::MaximiseCounterValuePool, fuzzcheck::sensors_and_pools::optimise_aggregate_stat_pool::OptimiseAggregateStatPool<fuzzcheck::sensors_and_pools::optimise_aggregate_stat_pool::SumOfCounterValues>>>> as fuzzcheck::traits::CompatibleWithSensor<fuzzcheck::code_coverage_sensor::CodeCoverageSensor>>::process ()
```