### PR TITLE
Add `DefaultMutator` for `std::borrow::Cow`.

### DIFF
--- a/fuzzcheck/src/mutators/cow.rs
+++ b/fuzzcheck/src/mutators/cow.rs
@@ -1,0 +1,24 @@
+use std::borrow::Cow;
+
+use crate::{DefaultMutator, Mutator};
+
+use super::map::MapMutator;
+
+impl<T> DefaultMutator for Cow<'static, T>
+where
+    T: DefaultMutator + Clone + 'static,
+{
+    type Mutator = impl Mutator<Cow<'static, T>>;
+
+    fn default_mutator() -> Self::Mutator {
+        MapMutator::new(
+            T::default_mutator(),
+            #[no_coverage]
+            |t: &Cow<T>| Some(t.clone().into_owned()),
+            #[no_coverage]
+            |t: &T| Cow::Owned(t.clone()),
+            #[no_coverage]
+            |_, cplx| cplx,
+        )
+    }
+}

--- a/fuzzcheck/src/mutators/mod.rs
+++ b/fuzzcheck/src/mutators/mod.rs
@@ -40,6 +40,7 @@ pub mod bool;
 pub mod boxed;
 pub mod char;
 pub mod character_classes;
+pub mod cow;
 pub mod dictionary;
 pub mod either;
 pub mod enums;


### PR DESCRIPTION
I'm not sure if this is the correct implementation.

I also don't think it's possible to have an implementation for `Cow<'a, T>` where `'a` < `'static`