### PR TITLE
Add optional support for `ron` serialization.

### DIFF
--- a/fuzzcheck/Cargo.toml
+++ b/fuzzcheck/Cargo.toml
@@ -18,6 +18,7 @@ cc = "1.0.73"
 grammar_mutator = []
 regex_grammar = ["grammar_mutator", "regex-syntax"]
 serde_json_serializer = ["serde", "serde_json"]
+serde_ron_serializer = ["serde", "ron"]
 
 default = ["grammar_mutator", "regex_grammar", "serde_json_serializer"]
 
@@ -35,6 +36,7 @@ fuzzcheck_common = { path = "../fuzzcheck_common", version = "0.12.0" }
 
 serde = { version = "1.0.139", features = ["derive"], optional = true }
 serde_json = { version = "1.0.82", optional = true }
+ron = { version = "0.7.1", optional = true }
 
 fuzzcheck_mutators_derive = { path = "../fuzzcheck_mutators_derive", version = "0.12.0" }
 
@@ -49,4 +51,3 @@ rustc-demangle = "0.1.21"
 [lib]
 name = "fuzzcheck"
 bench = false
-

--- a/fuzzcheck/src/builder.rs
+++ b/fuzzcheck/src/builder.rs
@@ -74,6 +74,8 @@ use crate::sensors_and_pools::{
     AndPool, DifferentObservations, MaximiseEachCounterPool, MaximiseObservationPool, MostNDiversePool,
     SameObservations, SimplestToActivateCounterPool, WrapperSensor,
 };
+#[cfg(feature = "serde_ron_serializer")]
+use crate::SerdeRonSerializer;
 #[cfg(feature = "serde_json_serializer")]
 use crate::SerdeSerializer;
 use crate::{
@@ -427,6 +429,27 @@ where
         }
     }
 }
+
+#[cfg(feature = "serde_ron_serializer")]
+impl<F, M, V> FuzzerBuilder2<F, M, V>
+where
+    F: Fn(&V) -> bool,
+    V: Clone + serde::Serialize + for<'e> serde::Deserialize<'e> + 'static,
+    M: Mutator<V>,
+{
+    /// Specify [`SerdeRonSerializer`] as the serializer to use when saving the
+    /// interesting test cases to the file system.
+    #[no_coverage]
+    pub fn serde_ron_serializer(self) -> FuzzerBuilder3<F, M, V> {
+        FuzzerBuilder3 {
+            test_function: self.test_function,
+            mutator: self.mutator,
+            serializer: Box::new(SerdeRonSerializer::<V>::default()),
+            _phantom: PhantomData,
+        }
+    }
+}
+
 impl<F, M, V> FuzzerBuilder3<F, M, V>
 where
     F: Fn(&V) -> bool,

--- a/fuzzcheck/src/lib.rs
+++ b/fuzzcheck/src/lib.rs
@@ -232,6 +232,9 @@ pub use sensors_and_pools::PoolExt;
 pub use sensors_and_pools::SensorExt;
 #[doc(inline)]
 pub use serializers::ByteSerializer;
+#[cfg(feature = "serde_ron_serializer")]
+#[doc(inline)]
+pub use serializers::SerdeRonSerializer;
 #[cfg(feature = "serde_json_serializer")]
 #[doc(inline)]
 pub use serializers::SerdeSerializer;

--- a/fuzzcheck/src/serializers/mod.rs
+++ b/fuzzcheck/src/serializers/mod.rs
@@ -11,11 +11,16 @@
 //! * [StringSerializer] encodes and decodes values of any type implementing
 //! `FromStr` and `ToString` into utf-8 encoded text files.
 
+#[cfg(feature = "serde_ron_serializer")]
+mod serde_ron_serializer;
 #[cfg(feature = "serde_json_serializer")]
 mod serde_serializer;
+
 use std::marker::PhantomData;
 use std::str::FromStr;
 
+#[cfg(feature = "serde_ron_serializer")]
+pub use serde_ron_serializer::SerdeRonSerializer;
 #[cfg(feature = "serde_json_serializer")]
 pub use serde_serializer::SerdeSerializer;
 

--- a/fuzzcheck/src/serializers/serde_ron_serializer.rs
+++ b/fuzzcheck/src/serializers/serde_ron_serializer.rs
@@ -1,0 +1,37 @@
+use std::marker::PhantomData;
+
+/// A serializer that uses [`serde`] and [`ron`] to serialize the test
+/// inputs (of arbitrary type `T: Serializable + for<'e> Deserializable<'e>`)
+/// to a "rusty object notation" file.
+#[doc(cfg(feature = "serde_ron_serializer"))]
+pub struct SerdeRonSerializer<S> {
+    phantom: PhantomData<S>,
+}
+
+impl<S> Default for SerdeRonSerializer<S> {
+    #[no_coverage]
+    fn default() -> Self {
+        Self { phantom: PhantomData }
+    }
+}
+
+impl<S> crate::traits::Serializer for SerdeRonSerializer<S>
+where
+    S: serde::Serialize + for<'e> serde::Deserialize<'e>,
+{
+    type Value = S;
+
+    #[no_coverage]
+    fn extension(&self) -> &str {
+        "ron"
+    }
+    #[no_coverage]
+    fn from_data(&self, data: &[u8]) -> Option<S> {
+        let utf8_encoded = std::str::from_utf8(data).ok()?;
+        ron::from_str(utf8_encoded).ok()
+    }
+    #[no_coverage]
+    fn to_data(&self, value: &Self::Value) -> Vec<u8> {
+        ron::to_string(value).unwrap().into_bytes()
+    }
+}


### PR DESCRIPTION
I find it a bit more readable. I would have raised an issue first, but it is a small patch so I just created it :).