### PR TITLE
Remove MacOS builds

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -34,10 +34,8 @@ jobs:
 
   fuzz-rust-crate:
     name: Fuzz Rust crate
-    runs-on: ${{ matrix.os }}
-    strategy:
-        matrix:
-            os: [ubuntu-latest, macOS-latest]
+    runs-on: ubuntu-latest
+    # todo: restore MacOS builds eventually
     steps:
       - uses: actions/checkout@master
       - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
They are failing (the coverage information is not correctly parsed). However, I cannot reproduce this issue on any bare-metal MacOS machines.