### PR TITLE
Fix coverage attribute in tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ serde = { version = "1.0", features = ["derive"] }
 Below is an example of how to use fuzz test. Note:
 1. every code related to fuzzcheck is conditional on `#[cfg(test)]` because we 
 don't want to carry the fuzzcheck dependency in normal builds
-2. the `#![cfg_attr(test, feature(no_coverage))]` is required by fuzzcheck’s procedural macros
+2. the `#![cfg_attr(test, feature(coverage_attribute))]` is required by fuzzcheck’s procedural macros
 3. the use of `derive(fuzzcheck::DefaultMutator)` makes a custom type fuzzable
 
 ```rust
-#![cfg_attr(fuzzing, feature(no_coverage))]
+#![cfg_attr(fuzzing, feature(coverage_attribute))]
 use serde::{Deserialize, Serialize};
 
 #[cfg_attr(fuzzing, derive(fuzzcheck::DefaultMutator))]

--- a/fuzzcheck/README.md
+++ b/fuzzcheck/README.md
@@ -52,11 +52,11 @@ serde = { version = "1.0", features = ["derive"] }
 Below is an example of how to use fuzz test. Note:
 1. every code related to fuzzcheck is conditional on `#[cfg(test)]` because we 
 don't want to carry the fuzzcheck dependency in normal builds
-2. the `#![cfg_attr(test, feature(no_coverage))]` is required by fuzzcheck’s procedural macros
+2. the `#![cfg_attr(test, feature(coverage_attribute))]` is required by fuzzcheck’s procedural macros
 3. the use of `derive(fuzzcheck::DefaultMutator)` makes a custom type fuzzable
 
 ```rust
-#![cfg_attr(fuzzing, feature(no_coverage))]
+#![cfg_attr(fuzzing, feature(coverage_attribute))]
 use serde::{Deserialize, Serialize};
 
 #[cfg_attr(fuzzing, derive(fuzzcheck::DefaultMutator))]

--- a/fuzzcheck_book/src/quick_start.md
+++ b/fuzzcheck_book/src/quick_start.md
@@ -23,8 +23,8 @@
     ```
 
 
-* Add `#![cfg_attr(fuzzing, feature(no_coverage))]` at the top of the root module (e.g. `src/lib.rs` for a library target)
-    * fuzzcheck’s procedural macros use the `no_coverage` attribute
+* Add `#![cfg_attr(fuzzing, feature(coverage_attribute))]` at the top of the root module (e.g. `src/lib.rs` for a library target)
+    * fuzzcheck’s procedural macros use the `coverage_attribute` attribute
 
 * In your library, integration test, or executable, create a test module, gated by `#[cfg(all(fuzzing, test))]` and add a `#[test]` function inside it
     ```rust ignore

--- a/fuzzcheck_book/src/tutorial1_setup.md
+++ b/fuzzcheck_book/src/tutorial1_setup.md
@@ -22,7 +22,7 @@ fuzzcheck = "0.12"
 
 At the top of `src/lib.rs` add the following line:
 ```rust ignore
-#![cfg_attr(fuzzing, feature(no_coverage))]
+#![cfg_attr(fuzzing, feature(coverage_attribute))]
 ```
 This is a rust-nightly feature that fuzzcheck’s procedural macros use.
 

--- a/fuzzcheck_book/src/tutorial1_writing_fuzz_target.md
+++ b/fuzzcheck_book/src/tutorial1_writing_fuzz_target.md
@@ -65,7 +65,7 @@ fn fuzz_test_tree() {
 <summary> Click here to reveal a recap of the code we have written so far. </summary>
 
 ```rust ignore
-#![cfg_attr(fuzzing, feature(no_coverage))]
+#![cfg_attr(fuzzing, feature(coverage_attribute))]
 use std::cmp::{self, Ordering};
 pub struct Node<T: Ord> {
     key: T,


### PR DESCRIPTION
This PR replaces `no_coverage` with `coverage_attribute` in tutorials (README, book) to work with `rustc 1.89.0-nightly`. Related to #53.