### PR TITLE
Added custom timeout for fuzz_rust_create to save time if it gets stuck

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -35,6 +35,7 @@ jobs:
   fuzz-rust-crate:
     name: Fuzz Rust crate
     runs-on: ubuntu-latest
+    timeout-minutes: 4
     # todo: restore MacOS builds eventually
     steps:
       - uses: actions/checkout@master


### PR DESCRIPTION
### Change Summary
Added custom timeout for `Fuzz Rust crate` job of the `Continuous integration` workflow based on historical data.

### More details
Over the last 31 successful runs, the `Fuzz Rust crate` job has a maximum runtime of 1 minutes (mean=1, std=1).

However, there are failed runs that fail after reaching the threshold of 6 hours that GitHub imposes. In other words, these jobs seem to get stuck, possibly for external or random reasons. 

One such example is [this](https://github.com/loiclec/fuzzcheck-rs/actions/runs/14678410263/job/41197953790) job run, that failed after 6 hours. More stuck jobs have been observed over the last six months, the first one on 2025-02-20 and the last one one on 2025-04-26, while more recent occurences are also possible because our dataset has a cutoff date around late May. With the proposed changes, a total of **53 hours would have been saved** over the last six months retrospectively, clearing the queue for other workflows and **speeding up the CI** of the project, while also **saving resources** in general.

The idea is to set a timeout to stop jobs that run much longer than their historical maximum, because such jobs are probably stuck and will simply fail with a timeout at 6 hours.

Our PR proposes to set the timeout to `max + 3*std = 4 minutes` where `max` and `std` (standard deviation) are derived from the history of 31 successful runs. This will provide sufficient margin if the workflow gets naturally slower in the future, but if you would prefer lower/higher threshold we would be happy to do it.

### Context
Hi,

We are a team of [researchers](https://www.ifi.uzh.ch/en/zest.html) from University of Zurich and we are currently working on energy optimizations in GitHub Actions workflows.

Thanks for your time on this.

Feel free to let us know (here or in the email below) if you have any questions, and thanks for putting in the time to read this.

Best regards,  
[Konstantinos Kitsios](https://www.ifi.uzh.ch/en/zest/team/konstantinos_kitsios.html)  
konstantinos.kitsios@uzh.ch